### PR TITLE
feat: 회원가입 시 이메일 인증 추가

### DIFF
--- a/src/main/java/com/smallsquare/common/exception/errorCode/UserErrorCode.java
+++ b/src/main/java/com/smallsquare/common/exception/errorCode/UserErrorCode.java
@@ -19,7 +19,8 @@ public enum UserErrorCode {
     REFRESH_TOKEN_EXPIRED("이미 만료된 Refresh Token입니다.", HttpStatus.CONFLICT),
     INACTIVE_ACCOUNT("탈퇴한 회원 계정입니다.", HttpStatus.FORBIDDEN),
     EMAIL_NOT_EXIST("존재하지 않는 이메일입니다.", HttpStatus.NOT_FOUND),
-    SAME_AS_OLD_PASSWORD("이전과 동일한 비밀번호는 사용할 수 없습니다.", HttpStatus.CONFLICT);
+    SAME_AS_OLD_PASSWORD("이전과 동일한 비밀번호는 사용할 수 없습니다.", HttpStatus.CONFLICT),
+    EMAIL_NOT_VERIFIED("이메일 인증이 완료되지 않았습니다.", HttpStatus.CONFLICT);
 
 
     private final String message;

--- a/src/main/java/com/smallsquare/modules/user/infrastructure/mail/MailService.java
+++ b/src/main/java/com/smallsquare/modules/user/infrastructure/mail/MailService.java
@@ -1,5 +1,8 @@
 package com.smallsquare.modules.user.infrastructure.mail;
 
+import com.smallsquare.modules.user.infrastructure.redis.RedisService;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.mail.SimpleMailMessage;
@@ -15,14 +18,15 @@ public class MailService {
 
     private final JavaMailSender mailSender;
     private final StringRedisTemplate redisTemplate;
+    private final RedisService redisService;
 
-    public void sendResetPasswordEmail(String toEmail) {
+    public void sendFindAndResetPassword(String toEmail) {
 
         // 1. UUID 토큰 생성
         String token = UUID.randomUUID().toString();
 
         // 2. redis에 저장할 key & value 설정
-        String key = "findPassword:token" + token;
+        String key = "findPassword:token:" + token;
         String value = toEmail;
 
         // 3. redis에 key & value 설정
@@ -32,12 +36,66 @@ public class MailService {
 
         // 4. 링크 주소를 포함한 메일 발송
         String resetLink = "http://localhost:8080/reset-password?token=" + token;
-        sendEmail(toEmail, resetLink);
+        sendFindAndResetEmailText(toEmail, resetLink);
     }
 
-    private void sendEmail(String toEmail, String resetLink) {
+    public void sendVerifyEmail(String toEmail) {
+
+        // 1. UUID 토큰 생성
+        String token = UUID.randomUUID().toString();
+
+        // 2. redis에 저장할 key & value 설정
+        String key = "verifyEmail:token:" + token;
+        String value = toEmail;
+
+        // 3. redis에 key & value 설정
+        redisTemplate.opsForValue().set(
+                key, value, Duration.ofMinutes(15)
+        );
+
+        // 4. 이메일 발송
+        String resetLink = "http://localhost:8080/verify-email?token=" + token;
+        sendVerifyEmailText(toEmail, resetLink);
+    }
+
+    public void verifyEmail (String token) {
+
+        // 1. redis key 설정
+        String key = "verifyEmail:token:" + token;
+
+        // 2. redis에서 해당 token 값 조회
+        String email = redisService.get(key);
+
+        // 3. 인증이 완료되면
+        String verifiedKey = "verifyEmail:email:" + email;
+
+        // 4. Redis에 새로운 키와 값으로 데이터를 저장 -> 회원 가입 로직에서 true인지 판별
+        redisTemplate.opsForValue().set(
+                verifiedKey, "true", Duration.ofMinutes(15)
+        );
+
+        redisTemplate.delete(key);
+
+    }
+
+    private void sendFindAndResetEmailText(String toEmail, String resetLink) {
         String subject = "[스몰스퀘어] 비밀번호 재설정 링크입니다.";
         String content = "아래 링크를 클릭하여 비밀번호를 재설정하세요.\n\n" +
+                resetLink + "\n\n" +
+                "이 링크는 15분간만 유효합니다.";
+
+        SimpleMailMessage message = new SimpleMailMessage();
+        message.setTo(toEmail);
+        message.setSubject(subject);
+        message.setText(content);
+        message.setFrom("smallsquare99@gmail.com");
+
+        mailSender.send(message);
+    }
+
+    private void sendVerifyEmailText(String toEmail, String resetLink) {
+        String subject = "[스몰스퀘어] 이메일 인증 링크입니다.";
+        String content = "아래 링크를 클릭하여 이메일 인증을 완료하세요.\n\n" +
                 resetLink + "\n\n" +
                 "이 링크는 15분간만 유효합니다.";
 

--- a/src/main/java/com/smallsquare/modules/user/web/controller/MailController.java
+++ b/src/main/java/com/smallsquare/modules/user/web/controller/MailController.java
@@ -1,16 +1,13 @@
 package com.smallsquare.modules.user.web.controller;
 
 import com.smallsquare.modules.user.infrastructure.mail.MailService;
-import com.smallsquare.modules.user.infrastructure.redis.RedisService;
 import com.smallsquare.modules.user.web.dto.request.MailReqDto;
+import com.smallsquare.modules.user.web.dto.request.UserVerifyEmailReqDto;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -20,8 +17,20 @@ public class MailController {
     private final MailService mailService;
 
     @PostMapping("/find/password")
-    public ResponseEntity<Void> sendTestMail(@Valid @RequestBody MailReqDto reqDto) {
-        mailService.sendResetPasswordEmail(reqDto.getEmail());
+    public ResponseEntity<Void> sendPasswordMail(@Valid @RequestBody MailReqDto reqDto) {
+        mailService.sendFindAndResetPassword(reqDto.getEmail());
+        return ResponseEntity.status(HttpStatus.OK).build();
+    }
+
+    @PostMapping("/sendVerifyEmail")
+    public ResponseEntity<Void> sendVerifyEmail(@Valid @RequestBody MailReqDto reqDto) {
+        mailService.sendVerifyEmail(reqDto.getEmail());
+        return ResponseEntity.status(HttpStatus.OK).build();
+    }
+
+    @PostMapping("/verifyEmail")
+    public ResponseEntity<Void> verifyEmail(@Valid @RequestBody UserVerifyEmailReqDto reqDto) {
+        mailService.verifyEmail(reqDto.getVerifyEmailToken());
         return ResponseEntity.status(HttpStatus.OK).build();
     }
 }

--- a/src/main/java/com/smallsquare/modules/user/web/dto/request/UserVerifyEmailReqDto.java
+++ b/src/main/java/com/smallsquare/modules/user/web/dto/request/UserVerifyEmailReqDto.java
@@ -1,0 +1,16 @@
+package com.smallsquare.modules.user.web.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter @Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserVerifyEmailReqDto {
+
+    @NotBlank(message = "Token은 필수값입니다.")
+    private String verifyEmailToken;
+}


### PR DESCRIPTION
- 이메일을 발송하고 사용자가 버튼을 누르면 GET /api/mail/verifyEmail 요청이 보내도록 설정 (프론트에서 추후 구현 예정)
- 요청이 들어오면 토큰을 통해 새로운 형식의 값을 Redis에 저장
- 회원 가입 시 검증 로직 추가